### PR TITLE
Upgrade ASM to version 6.1

### DIFF
--- a/buildScripts/ivy.xml
+++ b/buildScripts/ivy.xml
@@ -11,9 +11,9 @@
 		<dependency org="projectlombok.org" name="junit" rev="4.8.1" conf="test" />
 		<dependency org="com.jcraft" name="jsch" rev="0.1.42" conf="build->default" />
 		<dependency org="projectlombok.org" name="jsch-ant-fixed" rev="0.1.45" conf="build" />
-		<dependency org="org.ow2.asm" name="asm" rev="6.0" conf="runtime, build -> default; contrib->sources" />
-		<dependency org="org.ow2.asm" name="asm-tree" rev="6.0" conf="runtime, build->default; contrib->sources" />
-		<dependency org="org.ow2.asm" name="asm-commons" rev="6.0" conf="runtime, build->default; contrib->sources" />
+		<dependency org="org.ow2.asm" name="asm" rev="6.1" conf="runtime, build -> default; contrib->sources" />
+		<dependency org="org.ow2.asm" name="asm-tree" rev="6.1" conf="runtime, build->default; contrib->sources" />
+		<dependency org="org.ow2.asm" name="asm-commons" rev="6.1" conf="runtime, build->default; contrib->sources" />
 		<dependency org="net.java.dev.jna" name="jna" rev="3.2.2" conf="runtimeInjector, build->master" />
 	</dependencies>
 </ivy-module>


### PR DESCRIPTION
Upgrade ASM to version 6.1 that fixes Lombok issue [Compilation error of @SneakyThrows for generic exceptions in JDK 10](https://github.com/rzwitserloot/lombok/issues/1693)