### PR TITLE
Upgrade to ASM v8

### DIFF
--- a/buildScripts/ivy.xml
+++ b/buildScripts/ivy.xml
@@ -8,12 +8,12 @@
 		<conf name="contrib" />
 	</configurations>
 	<dependencies>
-		<dependency org="junit" name="junit" rev="4.12" conf="test -> default"/>
+		<dependency org="junit" name="junit" rev="4.13" conf="test -> default"/>
 		<dependency org="com.jcraft" name="jsch" rev="0.1.42" conf="build->default" />
 		<dependency org="projectlombok.org" name="jsch-ant-fixed" rev="0.1.45" conf="build" />
-		<dependency org="org.ow2.asm" name="asm" rev="7.2" conf="runtime, build -> default; contrib->sources" />
-		<dependency org="org.ow2.asm" name="asm-tree" rev="7.2" conf="runtime, build->default; contrib->sources" />
-		<dependency org="org.ow2.asm" name="asm-commons" rev="7.2" conf="runtime, build->default; contrib->sources" />
-		<dependency org="net.java.dev.jna" name="jna" rev="5.5.0" conf="runtimeInjector, build->master" />
+		<dependency org="org.ow2.asm" name="asm" rev="8.0.1" conf="runtime, build -> default; contrib->sources" />
+		<dependency org="org.ow2.asm" name="asm-tree" rev="8.0.1" conf="runtime, build->default; contrib->sources" />
+		<dependency org="org.ow2.asm" name="asm-commons" rev="8.0.1" conf="runtime, build->default; contrib->sources" />
+		<dependency org="net.java.dev.jna" name="jna" rev="5.6.0" conf="runtimeInjector, build->master" />
 	</dependencies>
 </ivy-module>

--- a/buildScripts/ivysettings.xml
+++ b/buildScripts/ivysettings.xml
@@ -4,7 +4,7 @@
 			<filesystem name="projectLocalRepo">
 				<ivy pattern="${ivy.settings.dir}/ivy-repo/[organisation]-[module]-[revision].xml" />
 			</filesystem>
-			<ibiblio name="maven-repo2" m2compatible="true" root="http://repo2.maven.org/maven2" />
+			<ibiblio name="maven-repo2" m2compatible="true" root="https://repo1.maven.org/maven2" />
 		</chain>
 	</resolvers>
 	<settings defaultResolver="projectRepos" />

--- a/src/patcher/lombok/patcher/Version.java
+++ b/src/patcher/lombok/patcher/Version.java
@@ -26,7 +26,7 @@ package lombok.patcher;
  */
 public class Version {
 	// ** CAREFUL ** - this class must always compile with 0 dependencies (it must not refer to any other sources or libraries).
-	private static final String VERSION = "0.36";
+	private static final String VERSION = "0.37";
 	
 	private Version() {
 		//Prevent instantiation


### PR DESCRIPTION
## Summary

Upgrades dependencies to:

- ASM v8
- JUnit 4.13
- JNA 5.6

Tested with: `ant dist` using `Apache Ant(TM) version 1.10.5 compiled on July 10 2018`.

## Background

This is done to prepare grounds for lombok working with JDK 14/15 and beyond. The current latest version of lombok fails to build against JDK 15:

```bash
error: Error during the transformation of 'org.apereo.cas.authentication.ProtocolAttributeEncoder'; 
post-compiler 'lombok.bytecode.SneakyThrowsRemover' caused an exception: 
java.lang.IllegalArgumentException: Unsupported class file major version 59
        at org.objectweb.asm.ClassReader.<init>(ClassReader.java:195)
        at org.objectweb.asm.ClassReader.<init>(ClassReader.java:176)
        at org.objectweb.asm.ClassReader.<init>(ClassReader.java:162)
        at lombok.bytecode.AsmUtil.fixJSRInlining(AsmUtil.java:37)
        at lombok.bytecode.SneakyThrowsRemover.applyTransformations(SneakyThrowsRemover.java:46)
        at lombok.core.PostCompiler.applyTransformations(PostCompiler.java:43)
        at lombok.core.PostCompiler$1.close(PostCompiler.java:76)
```

Lombok version: 1.18.12
JDK 15:

```
openjdk version "15" 2020-09-15
OpenJDK Runtime Environment Zulu15.27+17-CA (build 15+36)
OpenJDK 64-Bit Server VM Zulu15.27+17-CA (build 15+36, mixed mode, sharing)
```
