### PR TITLE
Update ASM and JNA libraries

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-#lombok.patcher
+# lombok.patcher
 
 Lombok Patcher gives you the ability to live-rewrite classes as a JVM runs, either by loading as an agent during JVM bootup or by injecting the agent 'live' during execution.
 

--- a/buildScripts/ivy.xml
+++ b/buildScripts/ivy.xml
@@ -11,9 +11,9 @@
 		<dependency org="junit" name="junit" rev="4.13" conf="test -> default"/>
 		<dependency org="com.jcraft" name="jsch" rev="0.1.42" conf="build->default" />
 		<dependency org="projectlombok.org" name="jsch-ant-fixed" rev="0.1.45" conf="build" />
-		<dependency org="org.ow2.asm" name="asm" rev="9.2" conf="runtime, build -> default; contrib->sources" />
-		<dependency org="org.ow2.asm" name="asm-tree" rev="9.2" conf="runtime, build->default; contrib->sources" />
-		<dependency org="org.ow2.asm" name="asm-commons" rev="9.2" conf="runtime, build->default; contrib->sources" />
-		<dependency org="net.java.dev.jna" name="jna" rev="5.6.0" conf="runtimeInjector, build->master" />
+		<dependency org="org.ow2.asm" name="asm" rev="9.4" conf="runtime, build -> default; contrib->sources" />
+		<dependency org="org.ow2.asm" name="asm-tree" rev="9.4" conf="runtime, build->default; contrib->sources" />
+		<dependency org="org.ow2.asm" name="asm-commons" rev="9.4" conf="runtime, build->default; contrib->sources" />
+		<dependency org="net.java.dev.jna" name="jna" rev="5.12.1" conf="runtimeInjector, build->master" />
 	</dependencies>
 </ivy-module>


### PR DESCRIPTION
Allows support for JDK 19 and 20. Please see https://asm.ow2.io/versions.html

Related: https://github.com/projectlombok/lombok/issues/3264 and https://github.com/projectlombok/lombok/pull/3251
