### PR TITLE
JDK 22: Bump ASM to 9.6

### DIFF
--- a/buildScripts/ivy.xml
+++ b/buildScripts/ivy.xml
@@ -11,9 +11,9 @@
 		<dependency org="junit" name="junit" rev="4.13" conf="test -> default"/>
 		<dependency org="com.jcraft" name="jsch" rev="0.1.42" conf="build->default" />
 		<dependency org="projectlombok.org" name="jsch-ant-fixed" rev="0.1.45" conf="build" />
-		<dependency org="org.ow2.asm" name="asm" rev="9.5" conf="runtime, build -> default; contrib->sources" />
-		<dependency org="org.ow2.asm" name="asm-tree" rev="9.5" conf="runtime, build->default; contrib->sources" />
-		<dependency org="org.ow2.asm" name="asm-commons" rev="9.5" conf="runtime, build->default; contrib->sources" />
+		<dependency org="org.ow2.asm" name="asm" rev="9.6" conf="runtime, build -> default; contrib->sources" />
+		<dependency org="org.ow2.asm" name="asm-tree" rev="9.6" conf="runtime, build->default; contrib->sources" />
+		<dependency org="org.ow2.asm" name="asm-commons" rev="9.6" conf="runtime, build->default; contrib->sources" />
 		<dependency org="net.java.dev.jna" name="jna" rev="5.12.1" conf="runtimeInjector, build->master" />
 	</dependencies>
 </ivy-module>


### PR DESCRIPTION
Upgrade the ASM library to support JDK 22.

```
30 September 2023: ASM 9.6 (tag ASM_9_6)
new Opcodes.V22 constant for Java 22
bug fixes
317991: Analyzer produces frames that have different locals than those detected by JRE bytecode verifier
317995: Invalid stackmap generated when the instruction stream has new instruction after invokespecial to <init>
317998: Analyzer can fail to catch thrown exceptions
318002: asm-analysis Frame allocates an array unnecessarily inside executeInvokeInsn
bug in CheckFrameAnalyzer with static methods
```

See https://asm.ow2.io/versions.html. 